### PR TITLE
fix incorrect WEBDAV_PUBLIC_READ logic

### DIFF
--- a/functions/webdav/[[path]].ts
+++ b/functions/webdav/[[path]].ts
@@ -45,7 +45,7 @@ export const onRequest: PagesFunction<{
   if (request.method === "OPTIONS") return handleRequestOptions();
 
   const skipAuth =
-    env.WEBDAV_PUBLIC_READ &&
+    env.WEBDAV_PUBLIC_READ === "1" &&
     ["GET", "HEAD", "PROPFIND"].includes(request.method);
 
   if (!skipAuth) {


### PR DESCRIPTION
even if you set WEBDAV_PUBLIC_READ to 0, the string "0" is still "truthy" by JavaScript, so the condition evaluates to true as long as the variable is set to any non-empty string
if a user follows the readme and sets WEBDAV_PUBLIC_READ = "0", their files are still publicly readable, this pull fixes that