### PR TITLE
feat: Implement HTTP chunked transfer encoding for WebDAV streaming uploads

### DIFF
--- a/functions/webdav/put.ts
+++ b/functions/webdav/put.ts
@@ -24,6 +24,65 @@ async function handleRequestPutMultipart({
   });
 }
 
+
+async function handleStreamedUpload({
+  bucket,
+  path,
+  request,
+}: RequestHandlerParams) {
+  const contentLength = request.headers.get("content-length");
+  const transferEncoding = request.headers.get("transfer-encoding");
+  
+  if (transferEncoding === "chunked" || !contentLength) {
+    // 处理 chunked transfer encoding
+    const reader = request.body?.getReader();
+    if (!reader) {
+      return new Response("Bad Request", { status: 400 });
+    }
+    
+    // 创建可写流来处理分块数据
+    const chunks: Uint8Array[] = [];
+    
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+      
+      // 合并所有分块
+      const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+      const combined = new Uint8Array(totalLength);
+      let offset = 0;
+      
+      for (const chunk of chunks) {
+        combined.set(chunk, offset);
+        offset += chunk.length;
+      }
+      
+      // 上传到 R2
+      const thumbnail = request.headers.get("fd-thumbnail");
+      const customMetadata = thumbnail ? { thumbnail } : undefined;
+      
+      const result = await bucket.put(path, combined, {
+        onlyIf: request.headers,
+        httpMetadata: request.headers,
+        customMetadata,
+      });
+      
+      if (!result) return new Response("Preconditions failed", { status: 412 });
+      return new Response("", { status: 201 });
+      
+    } catch (error) {
+      console.error("Stream upload error:", error);
+      return new Response("Internal Server Error", { status: 500 });
+    }
+  }
+  
+  // 回退到常规上传
+  return handleRegularUpload({ bucket, path, request });
+}
+
 export async function handleRequestPut({
   bucket,
   path,
@@ -46,6 +105,20 @@ export async function handleRequestPut({
     if (parentDir === null) return new Response("Conflict", { status: 409 });
   }
 
+  // 检查是否为流式上传
+  const transferEncoding = request.headers.get("transfer-encoding");
+  if (transferEncoding === "chunked") {
+    return handleStreamedUpload({ bucket, path, request });
+  }
+  
+  return handleRegularUpload({ bucket, path, request });
+}
+
+async function handleRegularUpload({
+  bucket,
+  path,
+  request,
+}: RequestHandlerParams) {
   const thumbnail = request.headers.get("fd-thumbnail");
   const customMetadata = thumbnail ? { thumbnail } : undefined;
 
@@ -56,6 +129,5 @@ export async function handleRequestPut({
   });
 
   if (!result) return new Response("Preconditions failed", { status: 412 });
-
   return new Response("", { status: 201 });
 }

--- a/src/app/transfer.ts
+++ b/src/app/transfer.ts
@@ -111,43 +111,6 @@ export async function blobDigest(blob: Blob) {
 
 export const SIZE_LIMIT = 100 * 1000 * 1000; // 100MB
 
-function xhrFetch(
-  url: RequestInfo | URL,
-  requestInit: RequestInit & {
-    onUploadProgress?: (progressEvent: ProgressEvent) => void;
-  }
-) {
-  return new Promise<Response>((resolve, reject) => {
-    const xhr = new XMLHttpRequest();
-    xhr.upload.onprogress = requestInit.onUploadProgress ?? null;
-    xhr.open(
-      requestInit.method ?? "GET",
-      url instanceof Request ? url.url : url
-    );
-    const headers = new Headers(requestInit.headers);
-    headers.forEach((value, key) => xhr.setRequestHeader(key, value));
-    xhr.onload = () => {
-      const headers = xhr
-        .getAllResponseHeaders()
-        .trim()
-        .split("\r\n")
-        .reduce((acc, header) => {
-          const [key, value] = header.split(": ");
-          acc[key] = value;
-          return acc;
-        }, {} as Record<string, string>);
-      resolve(new Response(xhr.responseText, { status: xhr.status, headers }));
-    };
-    xhr.onerror = reject;
-    if (
-      requestInit.body instanceof Blob ||
-      typeof requestInit.body === "string"
-    ) {
-      xhr.send(requestInit.body);
-    }
-  });
-}
-
 export async function copyPaste(source: string, target: string, move = false) {
   const uploadUrl = `${WEBDAV_ENDPOINT}${encodeKey(source)}`;
   const destinationUrl = new URL(
@@ -175,7 +138,6 @@ export async function createFolder(cwd: string) {
     console.log(`Create folder failed`);
   }
 }
-
 
 // 添加流式上传函数
 export async function streamUpload(
@@ -233,8 +195,6 @@ export async function streamUpload(
     duplex: 'half'
   });
 }
-
-
 
 // 流式上传单个分片
 async function streamChunk(


### PR DESCRIPTION
This PR implements true HTTP chunked transfer encoding for WebDAV file uploads, replacing the previous XMLHttpRequest-based approach with modern streaming APIs.
The above PR is to adapt to the chunked upload support of WebDAV in some software.